### PR TITLE
Fixing budgetpdfcard

### DIFF
--- a/iBudget/src/app/budget-pdf-card/budget-pdf-card.ts
+++ b/iBudget/src/app/budget-pdf-card/budget-pdf-card.ts
@@ -5,6 +5,7 @@ import { Component } from '@angular/core';
   imports: [],
   templateUrl: './budget-pdf-card.html',
   styleUrl: './budget-pdf-card.css',
+  standalone: true,
 })
 export class BudgetPdfCard {}
 

--- a/iBudget/src/app/user-info/user-info.html
+++ b/iBudget/src/app/user-info/user-info.html
@@ -19,7 +19,7 @@
     <!-- should contain components of a budget sheet. populate by grabbing from the database
          budget-pdf-card
         -->
-    <budget-pdf-card></budget-pdf-card>
+    <app-budget-pdf-card></app-budget-pdf-card>
     <h5>budget 9/2024</h5>
     <h5>budget 10/2024</h5>
     <h5>budget 11/2024</h5>


### PR DESCRIPTION
Fixed the error where the component was not found, reason why it was not found even though I imported correctly is that the selector that was specified in the budgetpdfcard component was different. it was app-budget-pdf-card while the one I imported and used was budget-pdf-card.